### PR TITLE
Allow GitHub token from ~/.githubtoken

### DIFF
--- a/eshgham/__init__.py
+++ b/eshgham/__init__.py
@@ -89,12 +89,19 @@ def get_token(arg_token, workflow_dict):
     # order of precedence (first listed trumps anything below)
     # 1. CLI argument
     # 2. yaml config
+    # 3. File ~/.githubtoken
     # 3. env var GITHUB_TOKEN
     token = None
     if 'token' in workflow_dict:
         token = workflow_dict.pop('token')
     if arg_token:
         token = arg_token
+    if not token:
+        token_file = os.path.expanduser("~/.githubtoken")
+        if os.path.exists(token_file):
+            with open(token_file) as file:
+                token = file.read().strip()
+
     if not token:
         token = os.environ.get("GITHUB_TOKEN")
     if not token:


### PR DESCRIPTION
With this, users can keep a file called `~/.githubtoken` containing their token, and that will be used if they don't provide a CLI argument or a value in their workflows file.