### PR TITLE
Add support to re-enable workflows

### DIFF
--- a/eshgham/__init__.py
+++ b/eshgham/__init__.py
@@ -71,7 +71,7 @@ def get_workflow_result(repo: github.Repository.Repository, workflow_name: str):
     if workflow.state != "active":
         try:
             success = workflow.enable()
-            status = Status.REENABLED
+
         except github.GithubException as exc:
             warnings.warn(
                 f"Unable to re-enable workflow {workflow_name}: {exc}",
@@ -175,7 +175,7 @@ def make_parser():
             "'FAILED', with a list of workflows as values. Each workflow "
             "has the repository name, the workflow name, and a URL. For "
             "passing/failing workflows, this URL points to the last run. "
-            "For inactive workflows, the URL points to the workflow itself."
+            "For inactive and re-enabled workflows, the URL points to the workflow itself."
         ),
     )
     parser.add_argument(

--- a/eshgham/tests/test_getdata.py
+++ b/eshgham/tests/test_getdata.py
@@ -6,28 +6,31 @@ from eshgham import Status, get_token, get_workflow_result
 
 
 @pytest.mark.parametrize(
-    "state,runs,status",
+    "state,runs,enable_result,status",
     [
-        ("inactive", [], Status.INACTIVATED),
-        ("active", [], Status.NO_SCHEDULED_RUNS),
+        ("inactive", [], False, Status.INACTIVATED),
+        ("inactive", [], True, Status.REENABLED),
+        ("active", [], False, Status.NO_SCHEDULED_RUNS),
         (
             "active",
             [SimpleNamespace(conclusion="failure", html_url="https://runs/fail")],
+            False,
             Status.FAILED,
         ),
         (
             "active",
             [SimpleNamespace(conclusion="success", html_url="https://runs/success")],
+            False,
             Status.OK,
         ),
     ],
 )
-def test_get_workflow_result(state, runs, status):
+def test_get_workflow_result(state, runs, enable_result, status):
     workflow = SimpleNamespace(
         state=state,
         path=".github/workflows/ci.yml",
         html_url="https://github.com/owner/repo/blob/main/.github/workflows/ci.yml",
-        enable=lambda: False,
+        enable=lambda: enable_result,
     )
 
     def get_runs(event):

--- a/eshgham/tests/test_getdata.py
+++ b/eshgham/tests/test_getdata.py
@@ -27,6 +27,7 @@ def test_get_workflow_result(state, runs, status):
         state=state,
         path=".github/workflows/ci.yml",
         html_url="https://github.com/owner/repo/blob/main/.github/workflows/ci.yml",
+        enable=lambda: False,
     )
 
     def get_runs(event):

--- a/eshgham/tests/test_main.py
+++ b/eshgham/tests/test_main.py
@@ -16,15 +16,20 @@ class FakeRun:
 
 
 class FakeWorkflow:
-    def __init__(self, repo_full_name, filename, *, state, runs):
+    def __init__(self, repo_full_name, filename, *, state, runs,
+                 enable_succeeds=False):
         self.state = state
         self.path = f".github/workflows/{filename}"
         self.html_url = f"https://github.com/{repo_full_name}/blob/main/{self.path}"
         self._runs = runs
+        self._enable_succeeds = enable_succeeds
 
     def get_runs(self, event):
         assert event == "schedule"
         return iter(self._runs)
+
+    def enable(self):
+        return self._enable_succeeds
 
 
 class FakeRepo:

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ classifiers =
 [options]
 python_requires = >=3.8
 install_requires =
-    pygithub
+    pygithub >=2.6.0
     colorama
     pyyaml
 packages = find:


### PR DESCRIPTION
This makes it so `eshgham` automatically re-enables inactive workflows (if the token has necessary permissions).

This involves some significant API breakage, since we add a new status type (and renumber an existing status type).