### PR TITLE
Add NullOutputter; --quiet flag

### DIFF
--- a/eshgham/__init__.py
+++ b/eshgham/__init__.py
@@ -17,6 +17,7 @@ __all__ = [
     "Outputter",
     "JSONOutputter",
     "ColorOutputter",
+    "NullOutputter",
     "Harness",
     "get_workflow_result",
     "attempt_to_reactivate",
@@ -177,6 +178,13 @@ def make_parser():
             "passing/failing workflows, this URL points to the last run. "
             "For inactive and re-enabled workflows, the URL points to the workflow itself."
         ),
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_const",
+        dest="runtype",
+        const="quiet",
+        help="Suppress all output.",
     )
     parser.add_argument(
         "--exit-code",
@@ -340,6 +348,10 @@ class ColorOutputter(Outputter):
         )
 
 
+class NullOutputter(Outputter):
+    """Outputter that emits no output; useful for programmatic use of the harness."""
+
+
 def main() -> int:
     """Returns the exit code"""
     parser = make_parser()
@@ -353,6 +365,7 @@ def main() -> int:
     outputter = {
         "json": JSONOutputter(),
         "color": ColorOutputter(),
+        "quiet": NullOutputter(),
     }[args.runtype]
 
     runner = Harness(outputter)

--- a/eshgham/tests/test_main.py
+++ b/eshgham/tests/test_main.py
@@ -60,7 +60,7 @@ class FakeGithub:
         return self._repos[repo_name]
 
 
-@pytest.mark.parametrize("output_format", ["json", "color"])
+@pytest.mark.parametrize("output_format", ["json", "color", "quiet"])
 def test_main(output_format, tmp_path, monkeypatch, capsys):
     repo_full_name = "owner/repo"
     workflows = {
@@ -106,6 +106,8 @@ def test_main(output_format, tmp_path, monkeypatch, capsys):
     ]
     if output_format == "json":
         argv.append("--json")
+    elif output_format == "quiet":
+        argv.append("--quiet")
 
     monkeypatch.setattr(sys, "argv", argv)
 
@@ -119,13 +121,15 @@ def test_main(output_format, tmp_path, monkeypatch, capsys):
         assert payload[Status.OK.name][0]["url"] == "https://runs/ci"
         assert payload[Status.FAILED.name][0]["url"] == "https://runs/lint"
         assert payload[Status.INACTIVATED.name][0]["url"].endswith("docs.yml")
-    else:
+    elif output_format == "color":
         out = captured.out
         assert f"{repo_full_name}: ci.yml:" in out
         assert f"{repo_full_name}: lint.yml:" in out
         assert "LINKS TO INACTIVE WORKFLOWS" in out
         assert "LINKS TO FAILED RUNS" in out
         assert "Checked 3 workflows." in out
+    else:
+        assert captured.out == ""
     assert captured.err == ""
 
 


### PR DESCRIPTION
This pull request adds a new "quiet" mode to the CLI, allowing users to suppress all output. It introduces a `NullOutputter` class (also useful for programmatic use of the code), updates the CLI parser to accept a `--quiet` flag, and extends test coverage to ensure this mode works as expected.